### PR TITLE
Add item link from supplier

### DIFF
--- a/app/views/suppliers/show.html.erb
+++ b/app/views/suppliers/show.html.erb
@@ -4,7 +4,7 @@
 		<% @listings.each do |listing|  %>	
 			<li>
 				<% item = Item.find(listing.item_id)  %>
-				Title: <%=  item.title  %></br>
+				Title: <%= link_to item.title, item_path(item)  %></br>
 				Description: <%= item.description  %></br>
 				Price: <%= number_to_currency(item.price) %></br>
 				Quantity:	<%= listing.quantity %></br>

--- a/app/views/suppliers/show.html.erb
+++ b/app/views/suppliers/show.html.erb
@@ -4,7 +4,7 @@
 		<% @listings.each do |listing|  %>	
 			<li>
 				<% item = Item.find(listing.item_id)  %>
-				Title: <%= item.title  %></br>
+				Title: <%=  item.title  %></br>
 				Description: <%= item.description  %></br>
 				Price: <%= number_to_currency(item.price) %></br>
 				Quantity:	<%= listing.quantity %></br>

--- a/note.txt
+++ b/note.txt
@@ -1,0 +1,1 @@
+refactor the supplier show page method to remove the Item call

--- a/note.txt
+++ b/note.txt
@@ -1,1 +1,2 @@
-refactor the supplier show page method to remove the Item call
+Group: discuss refactor of the supplier show page method to remove the Item call
+			 or re-structuring the relationships to lower unnecessary complexity

--- a/spec/features/user_can_filter_items_by_vendor_spec.rb
+++ b/spec/features/user_can_filter_items_by_vendor_spec.rb
@@ -38,7 +38,6 @@ feature "User Supplier Items" do
 		visit supplier_path(supplier.slug) 
 		expect(current_path).to eq("/fireproof")
 	
-		save_and_open_page
 		click_link("water purifier")
 		expect(page).to have_content(item.title)
 	end

--- a/spec/features/user_can_filter_items_by_vendor_spec.rb
+++ b/spec/features/user_can_filter_items_by_vendor_spec.rb
@@ -27,6 +27,19 @@ feature "User Supplier Items" do
 	end
 
 	scenario "User can view item's aggregate data by clicking link" do
+		supplier = Supplier.create(supplier_attributes)
+		item     = Item.create(item_attributes)
+		supplier.listings.create(
+														item_id: item.id, 
+														supplier_id: supplier.id, 
+														quantity: 3
+														)
 
+		visit supplier_path(supplier.slug) 
+		expect(current_path).to eq("/fireproof")
+	
+		save_and_open_page
+		click_link("water purifier")
+		expect(page).to have_content(item.title)
 	end
 end

--- a/spec/features/user_can_filter_items_by_vendor_spec.rb
+++ b/spec/features/user_can_filter_items_by_vendor_spec.rb
@@ -25,4 +25,8 @@ feature "User Supplier Items" do
 		click_link_or_button("Fireproof")
 		expect(page).to	have_content(item1.title)
 	end
+
+	scenario "User can view item's aggregate data by clicking link" do
+
+	end
 end


### PR DESCRIPTION
After you visit the suppliers show page and see a list of items. You can no click a link that will take you to a show page for that item. 
I still think we should re structure this relationship between item and supplier to no longer include the join table. Lets discuss this issue. If you would
like me to remove it I will work on this. Thanks Team :partly_sunny: 
