### PR TITLE
Fix username bug for supplier admin form modal

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,4 +23,8 @@ class User < ActiveRecord::Base
   def find_supplier_admin(id)
     SupplierAdmin.find_by(user_id: id)
   end
+
+	def element_name
+		fullname.split.join.delete('^a-zA-Z')
+	end
 end

--- a/app/views/suppliers/show.html.erb
+++ b/app/views/suppliers/show.html.erb
@@ -43,8 +43,8 @@
 							<li>
 								<%= user.fullname %>
 								<div class="create text-right">
-									<button type="button" class="btn btn-lg btn-default" data-toggle="modal" data-target=".reg-modal-<%= user.fullname.split.join  %>">Edit</button>
-									<div class="modal fade reg-modal-<%= user.fullname.split.join %>" id="admin-modal" tabindex="-1" role="dialog" aria-labelledby="mySmallModalLabel" aria-hidden="true">
+									<button type="button" class="btn btn-lg btn-default" data-toggle="modal" data-target=".reg-modal-<%= user.element_name %>">Edit</button>
+									<div class="modal fade reg-modal-<%= user.element_name %>" id="admin-modal" tabindex="-1" role="dialog" aria-labelledby="mySmallModalLabel" aria-hidden="true">
 										<div class="modal-dialog modal-lg">
 											<div class="modal-content">
 												<%= render partial: "partials/supplier_admin_edit_form", :locals => {:user => user }  %>


### PR DESCRIPTION
added a method in the user model to pull out non word characters. This way we can dynamically create class names for Modals that require specific classes. 
